### PR TITLE
Makes the repo public under the MIT license

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -28,9 +28,9 @@ branches:
       required_status_checks:
         strict: false
         contexts:
-          - Validate pull request / Pre-commit check
-          - Validate pull request / Run tests
-          - Validate pull request / Run integration test
+          - Pre-commit check
+          - Run tests
+          - Run integration test
       enforce_admins: false
       required_linear_history: true
       restrictions:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,7 +2,7 @@
 repository:
   name: render-j2-action
   description: Render a jinja template via j2cli in a Github Action
-  private: true
+  private: false
   has_issues: true
   default_branch: main
   allow_squash_merge: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Shop Smart, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Github Actions are basically useless as private repositories.

## Solution

<!-- How does this change fix the problem? -->

Sets the visibility to public and licenses it under MIT License.

## Notes

<!-- Additional notes here -->
