### PR TITLE
Installs requirements from full path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.x
-    - run: pip install -r requirements.txt
+    - run: pip install -r $GITHUB_ACTION_PATH/requirements.txt
       shell: bash
     - run: $GITHUB_ACTION_PATH/render.sh
       shell: bash


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
```

## Solution

<!-- How does this change fix the problem? -->

Use the actions path for requirements.

## Notes

<!-- Additional notes here -->

@shopsmart/web-team 