### PR TITLE
Properly handles multline strings for content

### DIFF
--- a/src/render.sh
+++ b/src/render.sh
@@ -4,10 +4,15 @@ function set-output() {
   if [ -f "$OUTPUT" ]; then
     echo "file=$OUTPUT" >> "$GITHUB_OUTPUT"
 
-    echo "[DEBUG] actual.yml=$(< actual.yml)" >&2
-
     # @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
     EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+
+    {
+      echo "debug=<<$EOF"
+      sed '2d' "$OUTPUT"
+      echo "$EOF"
+    } >> "$GITHUB_OUTPUT"
+
     {
       echo "content=<<$EOF"
       cat "$OUTPUT"

--- a/src/render.sh
+++ b/src/render.sh
@@ -2,12 +2,14 @@
 
 function set-output() {
   if [ -f "$OUTPUT" ]; then
-    echo "file=$OUTPUT" >> $GITHUB_OUTPUT
+    echo "file=$OUTPUT" >> "$GITHUB_OUTPUT"
 
+    # @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+    EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
     {
-      echo "content=<<EOF"
+      echo "content=<<$EOF"
       cat "$OUTPUT"
-      echo "EOF"
+      echo "$EOF"
     } >> "$GITHUB_OUTPUT"
   fi
 

--- a/src/render.sh
+++ b/src/render.sh
@@ -4,6 +4,8 @@ function set-output() {
   if [ -f "$OUTPUT" ]; then
     echo "file=$OUTPUT" >> "$GITHUB_OUTPUT"
 
+    echo "[DEBUG] actual.yml=$(< actual.yml)" >&2
+
     # @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
     EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
     {

--- a/src/render.sh
+++ b/src/render.sh
@@ -9,7 +9,7 @@ function set-output() {
 
     {
       echo "debug=<<$EOF"
-      sed '2d' "$OUTPUT"
+      sed '1,2d' "$OUTPUT"
       echo "$EOF"
     } >> "$GITHUB_OUTPUT"
 

--- a/src/render.sh
+++ b/src/render.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+function set-output() {
+  if [ -f "$OUTPUT" ]; then
+    echo "file=$OUTPUT" >> $GITHUB_OUTPUT
+
+    {
+      echo "content=<<EOF"
+      cat "$OUTPUT"
+      echo "EOF"
+    } >> "$GITHUB_OUTPUT"
+  fi
+
+  echo "[DEBUG] Output file not found, skipping outputs" >&2
+}
+
 function render() {
   set -eo pipefail
 
@@ -25,27 +39,7 @@ function render() {
   }
 
   # Main
-
-  function set_output() {
-    if [ -f "$OUTPUT" ]; then
-      echo "file=$OUTPUT" >> $GITHUB_OUTPUT
-
-      CONTENT="$(< "$OUTPUT")"
-
-      echo "[DEBUG] Condensing $(wc -l "$OUTPUT") lines" >&2
-
-      # Multiline variables need special treatment
-      # @see https://trstringer.com/github-actions-multiline-strings/
-      CONTENT="${CONTENT//'%'/'%25'}"
-      CONTENT="${CONTENT//$'\n'/'%0A'}"
-      CONTENT="${CONTENT//$'\r'/'%0D'}"
-
-      echo -n "content=$CONTENT" >> $GITHUB_OUTPUT
-    fi
-
-    echo "[DEBUG] Output file not found, skipping outputs" >&2
-  }
-  trap set_output EXIT
+  trap set-output EXIT
 
   local COMMAND=(j2 -o "$OUTPUT")
 

--- a/src/render.sh
+++ b/src/render.sh
@@ -7,11 +7,11 @@ function set-output() {
     # @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
     EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
 
-    {
-      echo "debug=<<$EOF"
-      sed '1,2d' "$OUTPUT"
-      echo "$EOF"
-    } >> "$GITHUB_OUTPUT"
+    # {
+      echo "debug=<<$EOF" >> "$GITHUB_OUTPUT"
+      sed '1,2d' "$OUTPUT" >> "$GITHUB_OUTPUT"
+      echo "$EOF" >> "$GITHUB_OUTPUT"
+    # } >> "$GITHUB_OUTPUT"
 
     # {
     #   echo "content=<<$EOF"

--- a/src/render.sh
+++ b/src/render.sh
@@ -12,9 +12,9 @@ function set-output() {
       cat "$OUTPUT"
       echo "$EOF"
     } >> "$GITHUB_OUTPUT"
+  else
+    echo "[DEBUG] Output file not found, skipping outputs" >&2
   fi
-
-  echo "[DEBUG] Output file not found, skipping outputs" >&2
 }
 
 function render() {

--- a/src/render.sh
+++ b/src/render.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 function set-output() {
+  set -x
   if [ -f "$OUTPUT" ]; then
     echo "file=$OUTPUT" >> "$GITHUB_OUTPUT"
 

--- a/src/render.sh
+++ b/src/render.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 function set-output() {
-  set -x
   if [ -f "$OUTPUT" ]; then
     echo "file=$OUTPUT" >> "$GITHUB_OUTPUT"
 
@@ -70,6 +69,8 @@ function render() {
 
   COMMAND+=("$TEMPLATE")
   [ -z "$DATA" ] || COMMAND+=("$DATA")
+
+  set -x
 
   which j2
   echo "[DEBUG] ${COMMAND[*]}" >&2

--- a/src/render.sh
+++ b/src/render.sh
@@ -13,11 +13,11 @@ function set-output() {
       echo "$EOF"
     } >> "$GITHUB_OUTPUT"
 
-    {
-      echo "content=<<$EOF"
-      cat "$OUTPUT"
-      echo "$EOF"
-    } >> "$GITHUB_OUTPUT"
+    # {
+    #   echo "content=<<$EOF"
+    #   cat "$OUTPUT"
+    #   echo "$EOF"
+    # } >> "$GITHUB_OUTPUT"
   else
     echo "[DEBUG] Output file not found, skipping outputs" >&2
   fi

--- a/src/render.sh
+++ b/src/render.sh
@@ -6,18 +6,11 @@ function set-output() {
 
     # @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
     EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-
-    # {
-      echo "debug=<<$EOF" >> "$GITHUB_OUTPUT"
-      sed '1,2d' "$OUTPUT" >> "$GITHUB_OUTPUT"
-      echo "$EOF" >> "$GITHUB_OUTPUT"
-    # } >> "$GITHUB_OUTPUT"
-
-    # {
-    #   echo "content=<<$EOF"
-    #   cat "$OUTPUT"
-    #   echo "$EOF"
-    # } >> "$GITHUB_OUTPUT"
+    {
+      echo "content<<$EOF"
+      cat "$OUTPUT"
+      echo "$EOF"
+    } >> "$GITHUB_OUTPUT"
   else
     echo "[DEBUG] Output file not found, skipping outputs" >&2
   fi


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

When changing the set-output syntax to the new `echo "{name}={value}" >> $GITHUB_OUTPUT`, multiline string handling needed to be changed.

## Solution

<!-- How does this change fix the problem? -->

Uses `HEREDOC` for content multline string.

## Notes

<!-- Additional notes here -->
