### PR TITLE
Allows multiple data files to be provided

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -46,7 +46,9 @@ jobs:
       - uses: ./
         with:
           template: fixtures/template.yml.j2
-          data: fixtures/data.yml
+          data: |
+            fixtures/data.yml
+            fixtures/secondary.yml
           format: yaml
           undefined: 'true'
           customize: fixtures/customize.py

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -57,6 +57,7 @@ jobs:
           output: actual.yml
           env_vars: |
             FOOBAR=baz
+          debug: true
 
       - name: 'Compare expected with actual'
         run: set -e; diff -yw actual.yml fixtures/expected.yml

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -57,7 +57,6 @@ jobs:
           output: actual.yml
           env_vars: |
             FOOBAR=baz
-          debug: true
 
       - name: 'Compare expected with actual'
         run: set -e; diff -yw actual.yml fixtures/expected.yml

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   debug:
     description: 'If true, sets -x in the shell command'
     required: false
-    default: false
+    default: 'false'
 
 outputs:
   file:

--- a/fixtures/data.yml
+++ b/fixtures/data.yml
@@ -1,3 +1,4 @@
 ---
 
 message: hello world
+secondary: bar

--- a/fixtures/expected.yml
+++ b/fixtures/expected.yml
@@ -6,4 +6,4 @@ bar: foo
 baz: baz
 foobar: foo
 empty: ""
-secondary: foo
+secondary: "foo"

--- a/fixtures/expected.yml
+++ b/fixtures/expected.yml
@@ -6,3 +6,4 @@ bar: foo
 baz: baz
 foobar: foo
 empty: ""
+secondary: foo

--- a/fixtures/secondary.yml
+++ b/fixtures/secondary.yml
@@ -1,0 +1,3 @@
+---
+
+secondary: foo

--- a/fixtures/template.yml.j2
+++ b/fixtures/template.yml.j2
@@ -6,3 +6,4 @@ bar: {{ foo | translate }}
 baz: {{ env('FOOBAR') }}
 foobar: {% if "foo" is foobar %}foo{% endif %}
 empty: "{{ nothere }}"
+secondary: "{{ secondary }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ j2cli==0.3.10
 Jinja2==3.0.2
 MarkupSafe==2.0.1
 PyYAML==6.0
+# TODO - Replace with a release when it comes out
+git+https://github.com/aisbergg/python-confmerge@06ec81b41043cc76d5fc60085daf3cfed2b610b1

--- a/src/render.sh
+++ b/src/render.sh
@@ -50,9 +50,11 @@ function render() {
   export TEMPFILE
 
   if [ -n "$DATA" ]; then
+    local ext=''
     local data_files=()
     while read -r file; do
       [ -n "$file" ] || continue
+      [ -n "$ext"  ] || ext="${file##*.}"
       [ -f "$file" ] || {
         echo "[ERROR] Data file not found: $file" >&2
         return 2

--- a/src/render.sh
+++ b/src/render.sh
@@ -15,7 +15,7 @@ function set-output() {
     echo "[DEBUG] Output file not found, skipping outputs" >&2
   fi
 
-  rm -f "$TEMPFILE"
+  rm -rf "$TEMP_DIRECTORY"
 }
 
 function render() {
@@ -46,8 +46,8 @@ function render() {
     return 3
   }
 
-  TEMPFILE="$(mktemp)"
-  export TEMPFILE
+  TEMP_DIRECTORY="$(mktemp -d)"
+  export TEMP_DIRECTORY
 
   if [ -n "$DATA" ]; then
     local ext=''
@@ -63,7 +63,7 @@ function render() {
     done <<< "$DATA"
 
     if [ ${#data_files[@]} -gt 1 ]; then
-      DATA="$TEMPFILE"
+      DATA="$TEMP_DIRECTORY/data.$ext"
       echo "[DEBUG] Merging ${data_files[*]} to $DATA" >&2
       confmerge "${data_files[@]}" "$DATA"
     fi

--- a/src/render.sh
+++ b/src/render.sh
@@ -36,9 +36,6 @@ function render() {
     VAR="${var^^}"
     val="${!VAR}"
     if [ -n "$val" ] && ! [ -f "$val" ]; then
-      whoami
-      ls -al "$(dirname "$val")"
-      ls -al "$val"
       echo "[ERROR] $var file not found: $val" >&2
       return 2
     fi

--- a/src/render.sh
+++ b/src/render.sh
@@ -55,6 +55,7 @@ function render() {
   if [ -n "$DATA" ]; then
     local data_files=()
     while read -r file; do
+      [ -n "$file" ] || continue
       [ -f "$file" ] || {
         echo "[ERROR] Data file not found: $file" >&2
         return 2

--- a/tests/render.bats
+++ b/tests/render.bats
@@ -13,7 +13,8 @@ function confmerge() {
 }
 
 function mktemp() {
-  echo "$TEST_TEMPFILE"
+  mkdir -p "$TEST_TEMP_DIRECTORY"
+  echo "$TEST_TEMP_DIRECTORY"
 }
 
 function setup() {
@@ -22,7 +23,7 @@ function setup() {
 
   export CONFMERGE_CMD_FILE="$BATS_TEST_TMPDIR/confmerge.cmd"
 
-  export TEST_TEMPFILE="$BATS_TEST_TMPDIR/tempfile"
+  export TEST_TEMP_DIRECTORY="$BATS_TEST_TMPDIR/tmp"
 
   # Use mock j2 and confmerge commands
   export -f \
@@ -180,6 +181,6 @@ $DATA_FILE_2"
 
   run render
 
-  grep -qE "$DATA_FILE_1 $DATA_FILE_2 $TEST_TEMPFILE\$" "$CONFMERGE_CMD_FILE"
-  grep -qE "$TEMPLATE $TEST_TEMPFILE\$" "$J2_CMD_FILE"
+  grep -qE "$DATA_FILE_1 $DATA_FILE_2 $TEST_TEMP_DIRECTORY/data.yml\$" "$CONFMERGE_CMD_FILE"
+  grep -qE "$TEMPLATE $TEST_TEMP_DIRECTORY/data.yml\$" "$J2_CMD_FILE"
 }

--- a/tests/render.bats
+++ b/tests/render.bats
@@ -3,18 +3,32 @@
 # shellcheck source=../render.sh
 source "$BATS_TEST_DIRNAME/../src/render.sh"
 
+function j2() {
+  echo "$*" >> "$J2_CMD_FILE"
+  env >> "$J2_ENV_FILE"
+}
+
+function confmerge() {
+  echo "$*" >> "$CONFMERGE_CMD_FILE"
+}
+
+function mktemp() {
+  echo "$TEST_TEMPFILE"
+}
+
 function setup() {
   export J2_CMD_FILE="$BATS_TEST_TMPDIR/j2.cmd"
   export J2_ENV_FILE="$BATS_TEST_TMPDIR/j2.env"
 
-  # Inject a mock j2 cli
-  mkdir -p "$BATS_TEST_TMPDIR/bin"
-  {
-    echo 'echo "$*" > "'$J2_CMD_FILE'"'
-    echo 'env > "'$J2_ENV_FILE'"'
-  } > "$BATS_TEST_TMPDIR/bin/j2"
-  chmod +x "$BATS_TEST_TMPDIR/bin/j2"
-  export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+  export CONFMERGE_CMD_FILE="$BATS_TEST_TMPDIR/confmerge.cmd"
+
+  export TEST_TEMPFILE="$BATS_TEST_TMPDIR/tempfile"
+
+  # Use mock j2 and confmerge commands
+  export -f \
+    j2 \
+    confmerge \
+    mktemp
 
   # Template is required (per action.yml)
   TEMPLATE="$BATS_TEST_TMPDIR/template.j2"
@@ -140,4 +154,32 @@ function teardown() {
   grep -q -- "-e FOO" "$J2_CMD_FILE"
   grep -q -- "--undefined" "$J2_CMD_FILE"
   grep -qE "$TEMPLATE $DATA\$" "$J2_CMD_FILE"
+}
+
+@test "it should not call confmerge when there is a single data file" {
+  export DATA="$BATS_TEST_TMPDIR/data.yml"
+
+  touch "$DATA"
+
+  run render
+
+  [ "$status" -eq 0 ]
+  [ -f "$CONFMERGE_CMD_FILE" ] # --version is called on it
+  [ "$(< "$CONFMERGE_CMD_FILE")" = "--version" ]
+}
+
+@test "it should merge files when multiple data files are provided" {
+  DATA_FILE_1="$BATS_TEST_TMPDIR/data.yml"
+  DATA_FILE_2="$BATS_TEST_TMPDIR/secondary.yml"
+
+  export DATA="$DATA_FILE_1
+$DATA_FILE_2"
+
+  touch "$DATA_FILE_1"
+  touch "$DATA_FILE_2"
+
+  run render
+
+  grep -qE "$DATA_FILE_1 $DATA_FILE_2 $TEST_TEMPFILE\$" "$CONFMERGE_CMD_FILE"
+  grep -qE "$TEMPLATE $TEST_TEMPFILE\$" "$J2_CMD_FILE"
 }


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to provide multiple data files to j2.  Unfortunately, j2cli does not support this... yet: https://github.com/kolypto/j2cli/issues/45.

## Solution

<!-- How does this change fix the problem? -->

Uses confmerge to merge multiple data files before passing to the j2cli.

## Notes

<!-- Additional notes here -->

If a single data file is provided, there is no change to how the action works.
