### PR TITLE
Replaces linuxbrew workaround with Homebrew/actions/setup-homebrew

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -32,7 +32,8 @@ jobs:
     name: 'Run tests'
     runs-on: ubuntu-latest
     steps:
-      - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+      - name: 'Setup Homebrew'
+        uses: Homebrew/actions/setup-homebrew@master
       - uses: actions/checkout@v2
       - run: brew install bats-core
       - run: bats -r tests/*.bats


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The workaround that Github gave when they removed brew from the runner is no longer valid.  They recommend using the Homebrew action.

## Solution

<!-- How does this change fix the problem? -->

Uses the Homebrew/actions/setup-homebrew action instead of adding to the PATH.

## Notes

<!-- Additional notes here -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205154556810810